### PR TITLE
add: pluginsディレクトリを生成し、lualineを導入

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -238,6 +238,7 @@ vim.opt.rtp:prepend(lazypath)
 --
 -- NOTE: Here is where you install your plugins.
 require('lazy').setup({
+  { import = 'plugins' },
   -- NOTE: Plugins can be added with a link (or for a github repo: 'owner/repo' link).
   'tpope/vim-sleuth', -- Detect tabstop and shiftwidth automatically
 

--- a/lua/plugins/lualine.lua
+++ b/lua/plugins/lualine.lua
@@ -1,0 +1,49 @@
+return {
+  'nvim-lualine/lualine.nvim',
+  config = function()
+    require('lualine').setup {
+      options = {
+        theme = 'tokyonight', -- 好みのテーマでOK
+        icons_enabled = true,
+        disabled_filetypes = { 'neo-tree', 'NvimTree' }, -- ステータスライン非表示にするbuffer
+      },
+      sections = {
+        lualine_a = { 'mode' },
+        lualine_b = { 'branch', 'diff' },
+        lualine_c = {
+          {
+            'filename',
+            path = 1, -- 0: ファイル名のみ, 1: 相対パス, 2: 絶対パス
+            symbols = {
+              modified = '●', -- 編集済み
+              readonly = '', -- 読み取り専用
+              unnamed = '[No Name]',
+            },
+          },
+        },
+        lualine_x = {
+          {
+            'diagnostics',
+            sources = { 'nvim_lsp' },
+            sections = { 'error', 'warn', 'info', 'hint' },
+            symbols = { error = ' ', warn = ' ', info = ' ', hint = ' ' },
+          },
+          'encoding',
+          'fileformat',
+          'filetype',
+        },
+        lualine_y = { 'progress' },
+        lualine_z = { 'location' },
+      },
+      inactive_sections = {
+        lualine_a = {},
+        lualine_b = {},
+        lualine_c = { 'filename' },
+        lualine_x = { 'location' },
+        lualine_y = {},
+        lualine_z = {},
+      },
+      extensions = { 'quickfix', 'toggleterm' },
+    }
+  end,
+}


### PR DESCRIPTION
# 作業
## kickstartをfolk
- [x] [kickstart 公式](https://github.com/nvim-lua/kickstart.nvim)を自分のリポジトリにfolk
- [x] ディレクトリを生成して、clone 
```bash
git clone git@github.com:common-member/kickstart.nvim.git ~/.config/nvim
```

## pluginsディレクトリを生成
- [x] プラグインを導入するためのディレクトリを生成
```bash
mkdir -p ~/.config/nvim/lua/plugins
```

## plugins/を読み込ませる
- [x] `~/.config/nvim/init.lua`を以下のように編集
```lua
require('lazy').setup({
  { import = 'plugins' }, -- ← これを追加
})
```

## lualineを導入
- [x] lualineプラグインファイルを生成
```bash
nvim ~/.config/nvim/lua/plugins/lualine.lua
```
- [x] lualineの内容を記述

# 備考
- [kickstart 公式](https://github.com/nvim-lua/kickstart.nvim)